### PR TITLE
Changed for-in loop to for loop when iterating unicode arrays

### DIFF
--- a/lib/js/emojione.js
+++ b/lib/js/emojione.js
@@ -345,9 +345,8 @@
     ns.toShort = function(str) { // this is really just unicodeToShortname() but I opted for the shorthand name to match toImage()
         for (var shortcode in ns.emojioneList) {
             if (!ns.emojioneList.hasOwnProperty(shortcode)) { continue; }
-            for (var ukey in ns.emojioneList[shortcode]) {
-                if (!ns.emojioneList[shortcode].hasOwnProperty(ukey)) { continue; }
-                var unicode = ns.emojioneList[shortcode][ukey].toUpperCase();
+            for(var i = 0, len = ns.emojioneList[shortcode].length; i < len; i++){
+                var unicode = ns.emojioneList[shortcode][i].toUpperCase();
                 str = ns.replaceAll(str,ns.convert(unicode),shortcode);
             }
         }
@@ -426,9 +425,8 @@
         var new_obj = {};
         for (var shortname in ns.emojioneList) {
             if (!ns.emojioneList.hasOwnProperty(shortname)) { continue; }
-            for (var ukey in ns.emojioneList[shortname]) {
-                if (!ns.emojioneList[shortname].hasOwnProperty(ukey)) { continue; }
-                new_obj[ns.emojioneList[shortname][ukey].toUpperCase()] = shortname;
+            for(var i = 0, len = ns.emojioneList[shortcode].length; i < len; i++){
+                new_obj[ns.emojioneList[shortname][i].toUpperCase()] = shortname;
             }
         }
         return new_obj;

--- a/package.json
+++ b/package.json
@@ -27,10 +27,15 @@
   "bugs": "https://github.com/Ranks/emojione/issues",
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-qunit": "^0.5.2",
+    "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-uglify": "^0.8.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-jsonlint": "^1.0.4"
+    "grunt-imageoptim": "^1.4.1",
+    "grunt-jsonlint": "^1.0.4",
+    "grunt-spritesmith": "^4.6.0",
+    "grunt-svgstore": "^0.5.0"
   }
 }


### PR DESCRIPTION
Couple of reasons for this can be found here:
http://stackoverflow.com/questions/500504/why-is-using-for-in-with-array
-iteration-such-a-bad-idea

I specifically ran into this because another library I’m using added a
method to the Array prototype, which this library then iterated every
pass.

This makes the property check someone else added unnecessary so I
removed it.

Also, I added some grunt packages that were in the grunt file, but
missing from package.json
